### PR TITLE
added test code assignment to user

### DIFF
--- a/components/Form/utils/handleSignUpSubmit.ts
+++ b/components/Form/utils/handleSignUpSubmit.ts
@@ -1,16 +1,35 @@
 import { upsertDocument } from "../../../services/firebase/queries/upsertDocument";
+import { auth, firestore } from "./../../../services/firebase/firebaseClient";
+import { collection, query, where, getDocs, doc, updateDoc } from "firebase/firestore";
 import form from "../../../data/signup.json";
 
 const handleSignUpSubmit = async (values: any, signup: Function, setLoading: Function) => {
     setLoading(true);
     try {
         await signup(values.email, values.password, values.username);
-        await upsertDocument("users", values, form, true);
+
+        let codes = await getDocs(
+            query(collection(firestore, "codes"), where("occupied", "==", false))
+        );
+        let result: any = []
+
+        codes.forEach((code) => {
+            result.push({...code.data(), id: code.id});
+        })
+
+        if (result.length !== 0) {
+            upsertDocument("users", { ...values, code: result[0].code }, form, true);
+            upsertDocument("codes", {username: values.username, occupied: true }, {}, true, result[0].id);
+        }
+        else {
+            upsertDocument("users", { ...values, code: "X99" }, form, true);
+        }
 
         // Add NOTIFICATION
         setLoading(false);
         return { status: "success" };
     } catch (e) {
+        console.log (e)
         setLoading(false);
 
         return { status: "failed", error: e };

--- a/data/signup.json
+++ b/data/signup.json
@@ -57,6 +57,11 @@
                 "validation": {
                     "matchesWith": "password"
                 }
+            },
+            {
+                "name": "code",
+                "label": "code",
+                "type": "hidden"
             }
         ]
     },

--- a/services/firebase/queries/upsertDocument.ts
+++ b/services/firebase/queries/upsertDocument.ts
@@ -9,7 +9,8 @@ export const upsertDocument = async (
     withSection: boolean = false,
     documentId?: string
 ) => {
-    let docValues = sanitizeValues(values, form, withSection);
+
+    let docValues = Object.keys(form).length === 0 ? values : sanitizeValues(values, form, withSection);
 
     if (documentId) {
         const ref = doc(firestore, collectionName, documentId);


### PR DESCRIPTION
During signup, query for available codes in Firestore. The first available record is assigned to the user signing up to the website. If no record is returned to be assigned, the default code to be assigned to the user is "X99".